### PR TITLE
add /survey redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "redirects": [
+      {
+        "source": "/survey",
+        "destination": "https://forms.gle/hpMZ3XbDqKbRgrG58"
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds a vercel redirect for `/survey` to the Google Form.

This will allow us to share `flushingtech.org/survey` in the meetup email blast.

Test by going to the preview site, and appending `/survey`

https://flushing-tech-website-git-survey-link-wilrnh-projects.vercel.app/survey